### PR TITLE
Deployed bastion and private VMs with managed identities

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -12,3 +12,13 @@ module "network" {
   resource_group_name = azurerm_resource_group.rg.name
   location            = var.resource_group_location
 }
+
+# for compute #
+
+module "compute" {
+  source              = "./modules/compute"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = var.resource_group_location
+  public_subnet_id    = module.network.public_subnet_id
+  private_subnet_id   = module.network.private_subnet_id
+}

--- a/modules/compute/main.tf
+++ b/modules/compute/main.tf
@@ -52,6 +52,10 @@ resource "azurerm_linux_virtual_machine" "bastion" {
         sku = "20_04-lts"
         version = "latest"
     }
+
+    identity {
+        type = "SystemAssigned"
+    }
 }
 
 resource "azurerm_network_interface" "private_nic" {
@@ -92,5 +96,9 @@ resource "azurerm_linux_virtual_machine" "private_vm" {
         offer = "0001-com-ubuntu-server-focal"
         sku = "20_04-lts"
         version = "latest"
+    }
+
+    identity {
+        type = "SystemAssigned"
     }
 }

--- a/modules/compute/main.tf
+++ b/modules/compute/main.tf
@@ -1,11 +1,96 @@
-# Compute Module: bastion VM in public subnet + private VM in private subnet
+#Generate SSH
+resource "tls_private_key" "bastion_ssh" {
+    algorithm = "RSA"
+    rsa_bits = 4096
+}
 
-# Example placeholder resource
-# resource "azurerm_linux_virtual_machine" "bastion" {
-#   name                = "bastion-vm"
-#   resource_group_name = var.resource_group
-#   location            = var.location
-#   size                = "Standard_B1s"
-#   admin_username      = "adminuser"
-#   network_interface_ids = []
-# }
+resource "azurerm_public_ip" "bastion_ip" {
+    name = "bastion-public-ip"
+    resource_group_name = var.resource_group_name
+    location = var.location
+    allocation_method = "Static"
+    sku = "Standard"
+}
+
+resource "azurerm_network_interface" "bastion_nic" {
+    name = "bastion-nic"
+    location = var.location
+    resource_group_name = var.resource_group_name
+
+    ip_configuration {
+        name = "internal"
+        subnet_id = var.public_subnet_id
+        private_ip_address_allocation = "Dynamic"
+        public_ip_address_id = azurerm_public_ip.bastion_ip.id
+    }
+}
+
+resource "azurerm_linux_virtual_machine" "bastion" {
+    name = "bastion-vm"
+    resource_group_name = var.resource_group_name
+    location = var.location
+    size = "Standard_B1s"
+
+    admin_username = "azureuser"
+    network_interface_ids = [
+        azurerm_network_interface.bastion_nic.id
+    ]
+
+    admin_ssh_key {
+        username = "azureuser"
+        public_key = tls_private_key.bastion_ssh.public_key_openssh
+    }
+
+    os_disk {
+        caching = "ReadWrite"
+        storage_account_type = "Standard_LRS"
+    }
+
+    source_image_reference {
+        publisher = "Canonical"
+        offer = "0001-com-ubuntu-server-focal"
+        sku = "20_04-lts"
+        version = "latest"
+    }
+}
+
+resource "azurerm_network_interface" "private_nic" {
+    name = "private-vm-nic"
+    location = var.location
+    resource_group_name = var.resource_group_name
+
+    ip_configuration {
+        name = "internal"
+        subnet_id = var.private_subnet_id
+        private_ip_address_allocation = "Dynamic"
+    }
+}
+
+resource "azurerm_linux_virtual_machine" "private_vm" {
+    name = "private-vm"
+    resource_group_name = var.resource_group_name
+    location = var.location
+    size = "Standard_B1s"
+
+    admin_username = "azureuser"
+    network_interface_ids = [
+        azurerm_network_interface.private_nic.id
+    ]
+
+    admin_ssh_key {
+        username = "azureuser"
+        public_key = tls_private_key.bastion_ssh.public_key_openssh
+    }
+
+    os_disk {
+        caching = "ReadWrite"
+        storage_account_type = "Standard_LRS"
+    }
+
+    source_image_reference {
+        publisher = "Canonical"
+        offer = "0001-com-ubuntu-server-focal"
+        sku = "20_04-lts"
+        version = "latest"
+    }
+}

--- a/modules/compute/outputs.tf
+++ b/modules/compute/outputs.tf
@@ -7,3 +7,13 @@ output "private_vm_id" {
   description = "The ID of the private VM"
   value = azurerm_linux_virtual_machine.private_vm.id
 }
+
+output "bastion_vm_principal_id" {
+  description = "Principal ID of the bastion VM managed identity"
+  value = azurerm_linux_virtual_machine.bastion.identity[0].principal_id
+}
+
+output "private_vm_principal_id" {
+  description = "Principal ID of the private VM managed identity"
+  value = azurerm_linux_virtual_machine.private_vm.identity[0].principal_id
+}

--- a/modules/compute/outputs.tf
+++ b/modules/compute/outputs.tf
@@ -1,9 +1,9 @@
-output "bastion_vm_id" {
-  description = "The ID of the bastion VM"
-  value       = "" # replace with resource reference
+output "bastion_vm_public_ip" {
+  description = "Public IP address of the bastion VM"
+  value       = azurerm_public_ip.bastion_ip.ip_address
 }
 
 output "private_vm_id" {
   description = "The ID of the private VM"
-  value       = "" # replace with resource reference
+  value = azurerm_linux_virtual_machine.private_vm.id
 }

--- a/modules/compute/variables.tf
+++ b/modules/compute/variables.tf
@@ -1,19 +1,19 @@
-variable "public_subnet_id" {
-  description = "The ID of the public subnet"
-  type        = string
-}
-
-variable "private_subnet_id" {
-  description = "The ID of the private subnet"
-  type        = string
-}
-
 variable "location" {
   description = "Deployment region"
   type        = string
 }
 
-variable "resource_group" {
-  description = "Resource group name (Azure only)"
+variable "resource_group_name" {
+  description = "Resource group name where VM will be created"
   type        = string
+}
+
+variable "public_subnet_id" {
+  description = "ID of the public subnet for bastion VM"
+  type        = string
+}
+
+variable "private_subnet_id" {
+  description = "ID of the private subnet for private VM"
+  type = string
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -18,3 +18,8 @@ output "public_subnet_id" {
 output "private_subnet_id" {
   value = module.network.private_subnet_id
 }
+
+# for compute #
+output "bastion_vm_ip" {
+  value = module.compute.bastion_vm_public_ip
+}


### PR DESCRIPTION
- Deployed bastion VM in public subnet.

- Deployed private VM in private subnet with no public IP.

- Enabled system-assigned managed identities for both VMs.

- Added outputs for bastion public IP and principal IDs.